### PR TITLE
新規登録時の利用規約の同意、利用規約をブラウザで表示 

### DIFF
--- a/componentsEx/organisms/Profile.js
+++ b/componentsEx/organisms/Profile.js
@@ -5,7 +5,7 @@ import { Block, Text, theme } from "galio-framework";
 import { createMaterialTopTabNavigator } from "@react-navigation/material-top-tabs";
 import Hr from "../atoms/Hr";
 import Icon from "../atoms/Icon";
-import { getPermissionAsync, onLoad, pickImage } from '../tools/imagePicker';
+import { getPermissionAsync, onLoad, pickImage } from '../tools/ImagePicker';
 import { alertModal, URLJoin } from "../tools/support";
 import Avatar from "../atoms/Avatar";
 import { useProfileState, useProfileDispatch } from "../tools/profileContext";

--- a/componentsEx/templates/SignInUpTemplate.js
+++ b/componentsEx/templates/SignInUpTemplate.js
@@ -1,7 +1,8 @@
 import React, { useState } from "react";
 import { Dimensions, StyleSheet, KeyboardAvoidingView, Platform, Keyboard } from "react-native";
-import { Block, Button, Input, Text, theme } from "galio-framework";
+import { Block, Button, Input, Text, theme, Checkbox } from "galio-framework";
 import { LinearGradient } from "expo-linear-gradient";
+import * as WebBrowser from 'expo-web-browser';
 
 import { HeaderHeight } from "../../constantsEx/utils";
 import BirthdayPicker from "../atoms/BirthdayPicker";
@@ -16,10 +17,12 @@ const SignInUp = (props) => {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [birthday, setBirthday] = useState();
+  const [userpolicy, setUserpolicy] = useState();
   const [active, setActive] = useState({
     username: false,
     email: false,
     password: false,
+    userpolicy: false
   });
   const errorMessagesInit = {
     username: "",
@@ -52,7 +55,7 @@ const SignInUp = (props) => {
   let buttonTextColor;
   let submit;
   let disabled = true;
-  if ((signup && username && email && password && birthday) || (signin && email && password)) {
+  if ((signup && username && email && password && birthday && userpolicy) || (signin && email && password)) {
     buttonColor = "lightcoral";
     buttonTextColor = "white";
     if (signup) {
@@ -65,6 +68,10 @@ const SignInUp = (props) => {
     buttonColor = "gainsboro";
     buttonTextColor = "silver";
   }
+
+  _handleOpenWithWebBrowser = () => {
+    WebBrowser.openBrowserAsync('https://www.fullfii.com/pages/privacy');
+  };
 
   return (
     <LinearGradient
@@ -164,6 +171,30 @@ const SignInUp = (props) => {
                 </>
               }
 
+            </Block>
+
+            <Block/>
+
+            <Block style={{ marginTop: 10, flexDirection: 'row', justifyContent: 'center', alignItems: 'center' }}>
+                <Checkbox
+                  color="#F69896"
+                  style={{ marginVertical: 8, marginHorizontal: 8, }}
+                  labelStyle={{ fontSize: 16 }}
+                  initialValue={active.userpolicy}
+                  onChange={(value) => {
+                    value ? setUserpolicy(true) : setUserpolicy(false);
+                  }}
+                  />
+                    <Text
+                      style={{color: '#0066c0'}}
+                      onPress={this._handleOpenWithWebBrowser}
+                      >利用規約
+                    </Text>
+                    <Text
+                      style={{color: '#F69896'}}
+                      onPress={this._handleOpenWithWebBrowser}
+                      >に同意する
+                    </Text>
             </Block>
             <Block flex top style={{ marginTop: 20 }}>
               {Array.isArray(errorMessages.error) &&

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "react-native-screens": "~2.2.0",
     "react-native-tab-view": "^2.15.1",
     "react-native-vector-icons": "^7.0.0",
-    "react-navigation-tabs": "^2.9.0"
+    "react-navigation-tabs": "^2.9.0",
+    "expo-web-browser": "~8.2.1"
   },
   "devDependencies": {
     "babel-preset-expo": "^8.2.1",

--- a/screensEx/Settings.js
+++ b/screensEx/Settings.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { StyleSheet, Dimensions, ScrollView, TouchableOpacity } from 'react-native';
 import { Block, theme, Text, Input, Button } from 'galio-framework';
+import * as WebBrowser from 'expo-web-browser';
 
 import { Hr, Icon } from '../componentsEx';
 import { useAuthDispatch } from '../componentsEx/tools/authContext';
@@ -14,6 +15,10 @@ const Settings = (props) => {
   const { navigation } = props;
   const [value, setValue] = useState("");
   const authDispatch = useAuthDispatch();
+
+  _handleOpenWithWebBrowser = () => {
+    WebBrowser.openBrowserAsync('https://www.fullfii.com/pages/privacy');
+  };
 
   if (typeof screen === "undefined")
     return (
@@ -36,8 +41,9 @@ const Settings = (props) => {
 
         <SettingsTitle title="Fullfiiについて" />
         <SettingsLabel title="バージョン" content="1.0.0" />
-        <SettingsCard title="利用規約" onPress={() => { }} />
-        <SettingsCard title="プライバシーポリシー" onPress={() => { }} />
+        <SettingsCard title="利用規約" onPress={this._handleOpenWithWebBrowser} />
+        <SettingsCard title="プライバシーポリシー" onPress={this._handleOpenWithWebBrowser} />
+        <SettingsCard title="特定商取引法に基づく表示" onPress={this._handleOpenWithWebBrowser} />
         <SettingsCard title="お問い合わせ" onPress={() => { }} />
       </ScrollView>
     );


### PR DESCRIPTION
➀新規登録時、利用規約の同意についてのチェックボックスの設置
⇒メアド、パスと同様チェックボックスに値がないと、完了ボタンは押せない
⇒利用規約はブラウザで表示するため、リンク機能の追加
参考）https://docs.expo.io/workflow/linking/?redirected
　　　WebBrowserというものを使ったので、expo install expo-web-browserが必要

➁設定画面の利用規約、プライバシーポリシー、特定商取引法を押した際に、上記と同じ仕組みでサイトの利用規約（https://www.fullfii.com/pages/privacy）に飛ぶ