### PR TITLE
お問い合わせと利用規約を新規登録時のみにする

### DIFF
--- a/componentsEx/templates/SignInUpTemplate.js
+++ b/componentsEx/templates/SignInUpTemplate.js
@@ -177,29 +177,33 @@ const SignInUp = (props) => {
 
             </Block>
 
-            <Block/>
+            {signup &&
+              <>
+                <Block/>
+                <Block style={{ marginTop: 10, flexDirection: 'row', justifyContent: 'center', alignItems: 'center' }}>
+                    <Checkbox
+                      color="#F69896"
+                      style={{ marginVertical: 8, marginHorizontal: 8, }}
+                      labelStyle={{ fontSize: 16 }}
+                      initialValue={active.userpolicy}
+                      onChange={(value) => {
+                        value ? setUserpolicy(true) : setUserpolicy(false);
+                      }}
+                      />
+                        <Text
+                          style={{color: '#0066c0'}}
+                          onPress={this._handleOpenWithWebBrowser}
+                          >利用規約
+                        </Text>
+                        <Text
+                          style={{color: '#F69896'}}
+                          onPress={this._handleOpenWithWebBrowser}
+                          >に同意する
+                        </Text>
+                </Block>
+              </>
+            }
 
-            <Block style={{ marginTop: 10, flexDirection: 'row', justifyContent: 'center', alignItems: 'center' }}>
-                <Checkbox
-                  color="#F69896"
-                  style={{ marginVertical: 8, marginHorizontal: 8, }}
-                  labelStyle={{ fontSize: 16 }}
-                  initialValue={active.userpolicy}
-                  onChange={(value) => {
-                    value ? setUserpolicy(true) : setUserpolicy(false);
-                  }}
-                  />
-                    <Text
-                      style={{color: '#0066c0'}}
-                      onPress={this._handleOpenWithWebBrowser}
-                      >利用規約
-                    </Text>
-                    <Text
-                      style={{color: '#F69896'}}
-                      onPress={this._handleOpenWithWebBrowser}
-                      >に同意する
-                    </Text>
-            </Block>
             <Block flex top style={{ marginTop: 20 }}>
               {Array.isArray(errorMessages.error) &&
                 errorMessages.error.map((message, index) => <BottomMessage style={{ marginBottom: 10, }} textcenter message={message} error key={index} />)

--- a/screensEx/Settings.js
+++ b/screensEx/Settings.js
@@ -19,7 +19,11 @@ const Settings = (props) => {
   const notificationDispatch = useNotificationDispatch();
 
   _handleOpenWithWebBrowser = () => {
-    WebBrowser.openBrowserAsync('https://www.fullfii.com/pages/privacy');
+    WebBrowser.openBrowserAsync("https://www.fullfii.com/pages/privacy");
+  };
+
+  _handleOpenWithWebBrowserContactUsForm = () => {
+    WebBrowser.openBrowserAsync("https://docs.google.com/forms/d/e/1FAIpQLScaGHQYXpvYtPPSIKqVgPdSgM5QY_dzOQeTG6j8Jz16bJWV3A/viewform?usp=sf_link");
   };
 
   if (typeof screen === "undefined")
@@ -46,7 +50,7 @@ const Settings = (props) => {
         <SettingsCard title="利用規約" onPress={this._handleOpenWithWebBrowser} />
         <SettingsCard title="プライバシーポリシー" onPress={this._handleOpenWithWebBrowser} />
         <SettingsCard title="特定商取引法に基づく表示" onPress={this._handleOpenWithWebBrowser} />
-        <SettingsCard title="お問い合わせ" onPress={() => { }} />
+        <SettingsCard title="お問い合わせ" onPress={this._handleOpenWithWebBrowserContactUsForm} />
       </ScrollView>
     );
   else if (screen === "InputMailAdress")


### PR DESCRIPTION
➀お問い合わせ機能追加
⇒googleformに飛ばす処理
➁利用規約を新規登録時のみにする
⇒ログイン時でも表れていたので、新規登録画面のみに修正