### PR TITLE
登録画面でのプラン選択とアプリ内のプラン選択画面

### DIFF
--- a/componentsEx/templates/SignInInTemplate.js
+++ b/componentsEx/templates/SignInInTemplate.js
@@ -1,0 +1,266 @@
+import React, { useState } from "react";
+import { Dimensions, StyleSheet, KeyboardAvoidingView, Platform, Keyboard } from "react-native";
+import { Block, Button, Input, Text, theme, Checkbox } from "galio-framework";
+import { LinearGradient } from "expo-linear-gradient";
+import * as WebBrowser from 'expo-web-browser';
+
+import { HeaderHeight } from "../../constantsEx/utils";
+import BirthdayPicker from "../atoms/BirthdayPicker";
+import { useAuthDispatch } from "../contexts/AuthContext";
+import { useProfileDispatch } from "../contexts/ProfileContext";
+import { useNotificationDispatch } from "../contexts/NotificationContext";
+import { useChatDispatch } from "../contexts/ChatContext";
+import { USER_POLICY_URL } from "../../constantsEx/env"
+
+const { height, width } = Dimensions.get("window");
+
+const SignInUp = (props) => {
+  const [username, setUsername] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [birthday, setBirthday] = useState();
+  const [userpolicy, setUserpolicy] = useState();
+  const [active, setActive] = useState({
+    username: false,
+    email: false,
+    password: false,
+    userpolicy: false
+  });
+  const errorMessagesInit = {
+    username: "",
+    email: "",
+    password: "",
+    birthday: "",
+    error: "", // common error message
+  };
+  const [isLoading, setIsLoading] = useState(false);
+  const [errorMessages, setErrorMessages] = useState(errorMessagesInit);
+  const [isOpenBirthdayPicker, setIsOpenBirthdayPicker] = useState(false);
+  const toggleIsOpenBirthdayPicker = (value) => {
+    Keyboard.dismiss();
+    setActive({ username: false, email: false, password: false, });
+    setIsOpenBirthdayPicker(value);
+  }
+
+  const toggleActive = (name, value) => {
+    active[name] = value;
+    const newActive = Object.assign({}, active);
+    setActive(newActive);
+  }
+
+  const dispatches = {
+    authDispatch: useAuthDispatch(),
+    profileDispatch: useProfileDispatch(),
+    notificationDispatch: useNotificationDispatch(),
+    chatDispatch: useChatDispatch(),
+  }
+
+  const { navigation, signup, signin, requestSignUp, requestSignIn } = props;
+  let buttonColor;
+  let buttonTextColor;
+  let submit;
+  let disabled = true;
+  if ((signup && username && email && password && birthday && userpolicy) || (signin && email && password)) {
+    buttonColor = "lightcoral";
+    buttonTextColor = "white";
+    if (signup) {
+      submit = () => requestSignUp(username, email, password, birthday, dispatches, setErrorMessages, errorMessagesInit, setIsLoading);
+    } else if (signin) {
+      submit = () => requestSignIn(email, password, dispatches, setErrorMessages, errorMessagesInit, setIsLoading);
+    }
+    disabled = false;
+  } else {
+    buttonColor = "gainsboro";
+    buttonTextColor = "silver";
+  }
+
+  _handleOpenWithWebBrowser = () => {
+    WebBrowser.openBrowserAsync(USER_POLICY_URL);
+  };
+
+  return (
+    <LinearGradient
+      start={{ x: 0, y: 0 }}
+      end={{ x: 0.25, y: 1.1 }}
+      locations={[0.2, 1]}
+      colors={["white", "mistyrose"]}
+      style={[styles.container, { flex: 1, paddingTop: theme.SIZES.BASE * 4 }]}>
+      <Block flex middle>
+        <KeyboardAvoidingView behavior="padding" enabled>
+          <Block flex={0.1} style={{ alignItems: "center" }}>
+            <Text size={26} bold color="#F69896">{signup ? "アカウントを作成" : (signin && "ログイン")}</Text>
+          </Block>
+          <Block flex={0.7} center space="between">
+            <Block center>
+              {signup &&
+                <>
+                  <Input
+                    bgColor="transparent"
+                    placeholderTextColor="darkgray"
+                    borderless
+                    color="lightcoral"
+                    placeholder="ユーザネーム"
+                    autoCapitalize="none"
+                    style={[styles.input, active.username ? styles.inputActive : null]}
+                    onChangeText={text => setUsername(text)}
+                    onBlur={() => toggleActive("username", false)}
+                    onFocus={() => toggleActive("username", true)}
+                    maxLength={15}
+                  />
+                  {(active.username && !Array.isArray(errorMessages.username)) && <BottomMessage message="あなたのニックネームを入力してください。" />}
+                  {Array.isArray(errorMessages.username) &&
+                    errorMessages.username.map((message, index) => <BottomMessage message={message} error key={index} />)
+                  }
+                </>
+              }
+
+              <Input
+                bgColor="transparent"
+                placeholderTextColor="darkgray"
+                borderless
+                color="lightcoral"
+                type="email-address"
+                placeholder="メールアドレス"
+                autoCapitalize="none"
+                style={[styles.input, active.email ? styles.inputActive : null]}
+                onChangeText={text => setEmail(text)}
+                onBlur={() => toggleActive("email", false)}
+                onFocus={() => toggleActive("email", true)}
+                maxLength={225}
+              />
+              {Array.isArray(errorMessages.email) &&
+                errorMessages.email.map((message, index) => <BottomMessage message={message} error key={index} />)
+              }
+
+              <Input
+                bgColor="transparent"
+                placeholderTextColor="darkgray"
+                borderless
+                color="lightcoral"
+                password
+                viewPass
+                placeholder="パスワード"
+                iconColor="#F69896"
+                style={[styles.input, active.password ? styles.inputActive : null]}
+                onChangeText={text => setPassword(text)}
+                onBlur={() => toggleActive("password", false)}
+                onFocus={() => toggleActive("password", true)}
+                maxLength={30}
+                textContentType={'oneTimeCode'}
+              />
+              {(active.password && !Array.isArray(errorMessages.password)) && <BottomMessage message="8文字以上" />}
+              {Array.isArray(errorMessages.password) &&
+                errorMessages.password.map((message, index) => <BottomMessage message={message} error key={index} />)
+              }
+
+              {signup &&
+                <>
+                  <Block>
+                    <Button shadowless color="transparent" style={{ position: "absolute" }} onPress={() => toggleIsOpenBirthdayPicker(true)} />
+                    <Input
+                      defaultValue={typeof birthday === "undefined" ? null : `${birthday.getFullYear()}年${birthday.getMonth() + 1}月${birthday.getDate()}日`}
+                      bgColor="transparent"
+                      placeholderTextColor="darkgray"
+                      borderless
+                      color="lightcoral"
+                      placeholder="生年月日"
+                      style={[styles.input, isOpenBirthdayPicker ? styles.inputActive : null]}
+                      editable={false}
+                      selectTextOnFocus={false}
+                    />
+                  </Block>
+                  {Array.isArray(errorMessages.birthday) &&
+                    errorMessages.birthday.map((message, index) => <BottomMessage message={message} error key={index} />)
+                  }
+                  <BirthdayPicker birthday={birthday} setBirthday={setBirthday} isOpen={isOpenBirthdayPicker} setIsOpen={toggleIsOpenBirthdayPicker} />
+                </>
+              }
+
+            </Block>
+
+            {signup &&
+              <>
+                <Block/>
+                <Block style={{ marginTop: 10, flexDirection: 'row', justifyContent: 'center', alignItems: 'center' }}>
+                    <Checkbox
+                      color="#F69896"
+                      style={{ marginVertical: 8, marginHorizontal: 8, }}
+                      labelStyle={{ fontSize: 16 }}
+                      initialValue={active.userpolicy}
+                      onChange={(value) => {
+                        value ? setUserpolicy(true) : setUserpolicy(false);
+                      }}
+                      />
+                        <Text
+                          style={{color: '#0066c0'}}
+                          onPress={this._handleOpenWithWebBrowser}
+                          >利用規約
+                        </Text>
+                        <Text
+                          style={{color: '#F69896'}}
+                          onPress={this._handleOpenWithWebBrowser}
+                          >に同意する
+                        </Text>
+                </Block>
+              </>
+            }
+
+            <Block flex top style={{ marginTop: 20 }}>
+              {Array.isArray(errorMessages.error) &&
+                errorMessages.error.map((message, index) => <BottomMessage style={{ marginBottom: 10, }} textcenter message={message} error key={index} />)
+              }
+
+              <Button
+                round
+                style={{ height: 48, shadowColor: buttonColor }}
+                color={buttonColor}
+                disabled={disabled}
+                onPress={submit}
+                loading={isLoading}
+              >
+                <Text color={buttonTextColor} size={16} bold>完了</Text>
+              </Button>
+
+              {signup &&
+                <Button color="transparent" shadowless onPress={() => navigation.navigate("SignIn")}>
+                  <Text center color="#F69896" size={theme.SIZES.FONT * 0.75}>すでにアカウントをお持ちですか？ サインイン</Text>
+                </Button>
+              }
+              {signin &&
+                <Button color="transparent" shadowless onPress={() => navigation.navigate("SignUp")}>
+                  <Text center color="#F69896" size={theme.SIZES.FONT * 0.75}>アカウントをお持ちではありませんか？サインアップ</Text>
+                </Button>
+              }
+            </Block>
+          </Block>
+        </KeyboardAvoidingView>
+      </Block>
+    </LinearGradient>
+  );
+}
+
+export default SignInUp;
+
+const BottomMessage = (props) => {
+  const { message, error, style, textcenter } = props;
+  return (
+    <Block style={[{ alignSelf: "flex-start", width: width * 0.9 }, style]}>
+      <Text color={error ? "cornflowerblue" : "lightgray"} bold={error} style={{ alignSelf: textcenter ? "center" : "flex-start" }}>{message}</Text>
+    </Block>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    marginTop: Platform.OS === "android" ? -HeaderHeight : 0,
+  },
+  input: {
+    width: width * 0.9,
+    borderRadius: 0,
+    borderBottomWidth: 1,
+    borderBottomColor: "#F69896",
+  },
+  inputActive: {
+    borderBottomWidth: 2,
+  },
+});

--- a/componentsEx/templates/SignInUpTemplate.js
+++ b/componentsEx/templates/SignInUpTemplate.js
@@ -1,6 +1,6 @@
-import React, { useState } from "react";
-import { Dimensions, StyleSheet, KeyboardAvoidingView, Platform, Keyboard } from "react-native";
-import { Block, Button, Input, Text, theme, Checkbox } from "galio-framework";
+import React, { useRef, useState } from "react";
+import { Dimensions, StyleSheet, KeyboardAvoidingView, Platform, Keyboard, ScrollView } from "react-native";
+import { Block, Button, Input, Text, theme, Checkbox, Icon } from "galio-framework";
 import { LinearGradient } from "expo-linear-gradient";
 import * as WebBrowser from 'expo-web-browser';
 
@@ -15,6 +15,7 @@ import { USER_POLICY_URL } from "../../constantsEx/env"
 const { height, width } = Dimensions.get("window");
 
 const SignInUp = (props) => {
+
   const [username, setUsername] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -78,6 +79,279 @@ const SignInUp = (props) => {
     WebBrowser.openBrowserAsync(USER_POLICY_URL);
   };
 
+  
+  const [currentPage, setCurrentPage] = useState(1);
+  const maxPage = 1;
+  const scrollView = useRef(null);
+
+  const goNextPage = () => {
+    scrollView.current.scrollTo({ y: 0, x: width * currentPage, animated: true });
+    setCurrentPage(currentPage - 1);
+  }
+
+  const pushNext = () => {
+      goNextPage();
+  }
+
+  const goPrevPage = () => {
+    scrollView.current.scrollTo({ y: 0, x: width * currentPage, animated: true });
+    setCurrentPage(currentPage + 1);
+  }
+
+  const pushBack = () => {
+      goPrevPage();
+  }
+
+  const FirstPage = () => {
+
+  return (
+    <Block flex middle style={styles.endConsultationContainer}>
+      <KeyboardAvoidingView behavior="padding" enabled>
+        <Block flex={0.1} style={{ alignItems: "center" }}>
+          <Text size={26} bold color="#F69896">{signup ? "アカウントを作成" : (signin && "ログイン")}</Text>
+        </Block>
+        <Block flex={0.7} center space="between">
+          <Block center>
+            {signup &&
+              <>
+                <Input
+                  bgColor="transparent"
+                  placeholderTextColor="darkgray"
+                  borderless
+                  color="lightcoral"
+                  placeholder="ユーザネーム"
+                  autoCapitalize="none"
+                  style={[styles.input, active.username ? styles.inputActive : null]}
+                  onChangeText={text => setUsername(text)}
+                  onBlur={() => toggleActive("username", false)}
+                  onFocus={() => toggleActive("username", true)}
+                  maxLength={15}
+                />
+                {(active.username && !Array.isArray(errorMessages.username)) && <BottomMessage message="あなたのニックネームを入力してください。" />}
+                {Array.isArray(errorMessages.username) &&
+                  errorMessages.username.map((message, index) => <BottomMessage message={message} error key={index} />)
+                }
+              </>
+            }
+
+            <Input
+              bgColor="transparent"
+              placeholderTextColor="darkgray"
+              borderless
+              color="lightcoral"
+              type="email-address"
+              placeholder="メールアドレス"
+              autoCapitalize="none"
+              style={[styles.input, active.email ? styles.inputActive : null]}
+              onChangeText={text => setEmail(text)}
+              onBlur={() => toggleActive("email", false)}
+              onFocus={() => toggleActive("email", true)}
+              maxLength={225}
+            />
+            {Array.isArray(errorMessages.email) &&
+              errorMessages.email.map((message, index) => <BottomMessage message={message} error key={index} />)
+            }
+
+            <Input
+              bgColor="transparent"
+              placeholderTextColor="darkgray"
+              borderless
+              color="lightcoral"
+              password
+              viewPass
+              placeholder="パスワード"
+              iconColor="#F69896"
+              style={[styles.input, active.password ? styles.inputActive : null]}
+              onChangeText={text => setPassword(text)}
+              onBlur={() => toggleActive("password", false)}
+              onFocus={() => toggleActive("password", true)}
+              maxLength={30}
+              textContentType={'oneTimeCode'}
+            />
+            {(active.password && !Array.isArray(errorMessages.password)) && <BottomMessage message="8文字以上" />}
+            {Array.isArray(errorMessages.password) &&
+              errorMessages.password.map((message, index) => <BottomMessage message={message} error key={index} />)
+            }
+
+            {signup &&
+              <>
+                <Block>
+                  <Button shadowless color="transparent" style={{ position: "absolute" }} onPress={() => toggleIsOpenBirthdayPicker(true)} />
+                  <Input
+                    defaultValue={typeof birthday === "undefined" ? null : `${birthday.getFullYear()}年${birthday.getMonth() + 1}月${birthday.getDate()}日`}
+                    bgColor="transparent"
+                    placeholderTextColor="darkgray"
+                    borderless
+                    color="lightcoral"
+                    placeholder="生年月日"
+                    style={[styles.input, isOpenBirthdayPicker ? styles.inputActive : null]}
+                    editable={false}
+                    selectTextOnFocus={false}
+                  />
+                </Block>
+                {Array.isArray(errorMessages.birthday) &&
+                  errorMessages.birthday.map((message, index) => <BottomMessage message={message} error key={index} />)
+                }
+                <BirthdayPicker birthday={birthday} setBirthday={setBirthday} isOpen={isOpenBirthdayPicker} setIsOpen={toggleIsOpenBirthdayPicker} />
+              </>
+            }
+
+          </Block>
+
+          {signup &&
+            <>
+              <Block/>
+              <Block style={{ marginTop: 10, flexDirection: 'row', justifyContent: 'center', alignItems: 'center' }}>
+                  <Checkbox
+                    color="#F69896"
+                    style={{ marginVertical: 8, marginHorizontal: 8, }}
+                    labelStyle={{ fontSize: 16 }}
+                    initialValue={active.userpolicy}
+                    onChange={(value) => {
+                      value ? setUserpolicy(true) : setUserpolicy(false);
+                    }}
+                    />
+                      <Text
+                        style={{color: '#F69896'}}
+                        onPress={_handleOpenWithWebBrowser}
+                        >利用規約
+                      </Text>
+                      <Text
+                        style={{color: '#F69896'}}
+                        onPress={_handleOpenWithWebBrowser}
+                        >に同意する
+                      </Text>
+              </Block>
+            </>
+          }
+
+          <Block flex top style={{ marginTop: 20 }}>
+            {Array.isArray(errorMessages.error) &&
+              errorMessages.error.map((message, index) => <BottomMessage style={{ marginBottom: 10, }} textcenter message={message} error key={index} />)
+            }
+
+            <Button
+              round
+              style={{ height: 48, shadowColor: buttonColor }}
+              color={buttonColor}
+              disabled={disabled}
+              onPress={pushNext}
+              loading={isLoading}
+            >
+              <Text color={buttonTextColor} size={16} bold>次に進む</Text>
+            </Button>
+
+            {signup &&
+              <Button color="transparent" shadowless onPress={() => navigation.navigate("SignIn")}>
+                <Text center color="#F69896" size={theme.SIZES.FONT * 0.75}>すでにアカウントをお持ちですか？ サインイン</Text>
+              </Button>
+            }
+            {signin &&
+              <Button color="transparent" shadowless onPress={() => navigation.navigate("SignUp")}>
+                <Text center color="#F69896" size={theme.SIZES.FONT * 0.75}>アカウントをお持ちではありませんか？サインアップ</Text>
+              </Button>
+            }
+          </Block>
+        </Block>
+      </KeyboardAvoidingView>
+    </Block>
+  );
+  }
+
+  const SecondPage = () => {
+    return (
+      <Block flex middle style={styles.endConsultationContainer}>
+      <KeyboardAvoidingView behavior="padding" enabled>
+        <Block style={{ alignItems: "left" }}>
+          <Icon family="font-awesome" name="chevron-left" size={15} color="silver" onPress={pushBack}/>
+        </Block>
+        <Block flex={0.1} style={{ alignItems: "center" }}>
+          <Text size={26} bold color="#F69896">{signup ? "プランの選択" : (signin && "ログイン")}</Text>
+        </Block>
+        <Block flex={0.7} center space="between">
+          
+          <Block flex style={{ marginTop: 20 }}>
+            {Array.isArray(errorMessages.error) &&
+              errorMessages.error.map((message, index) => <BottomMessage style={{ marginBottom: 10, }} textcenter message={message} error key={index} />)
+            }
+  
+            <Button
+              style={{ height: 80, shadowColor: "lightcoral", borderRadius: 20 }}
+              color="lightcoral"
+              disabled={disabled}
+              onPress={submit}
+              loading={isLoading}
+            >
+              <Text color="white" size={20} bold>2週間無料お試し</Text>
+            </Button>
+            <Block style={{padding: 10, paddingBottom: 20}}>
+              <Text color="silver" size={12} bold center>お試し期間終了後自動でノーマルに更新されます。</Text>
+              <Text color="silver" size={12} bold center>キャンセルしない限り、プランは毎月自動更新されます。</Text>
+            </Block>
+  
+            <Button
+              style={{ height: 80, shadowColor: "lightcoral", borderRadius: 20 }}
+              color="lightcoral"
+              disabled={disabled}
+              onPress={submit}
+              loading={isLoading}
+            >
+              <Text color="white" size={20} bold>ノーマル</Text>
+              <Text color="white" size={16} bold>￥500 / 月</Text>
+            </Button>
+            <Block style={{padding: 10, paddingBottom: 20}}>
+              <Text color="silver" size={12} bold center>キャンセルしない限り、プランは毎月自動更新されます。</Text>
+            </Block>
+            <Button
+              style={{ height: 80, shadowColor: "lightcoral", borderRadius: 20 }}
+              color="lightcoral"
+              disabled={disabled}
+              onPress={submit}
+              loading={isLoading}
+            >
+              <Text color="white" size={20} bold>1month</Text>
+              <Text color="white" size={16} bold>￥700　一ヶ月のみ</Text>
+            </Button>
+            <Block style={{padding: 10, paddingBottom: 20}}>
+              <Text color="silver" size={12} bold center>一ヶ月のみのプランです。</Text>
+            </Block>
+  
+            <Block style={{padding: 10}}>
+              <Text color="lightcoral" size={12} bold center>購入を復元する</Text>
+            </Block>
+            <Block style={{padding: 10, flexDirection: 'row', justifyContent: 'center', alignItems: 'center'}}>
+            <Text color="#F69896" size={12} bold center onPress={_handleOpenWithWebBrowser}
+              >利用規約
+            </Text>
+            <Text
+              color="silver" size={12} bold center
+              >と
+            </Text>
+              <Text
+              color="#F69896" size={12} bold center
+              onPress={_handleOpenWithWebBrowser}
+              >プライバシーポリシー
+            </Text>
+            </Block>
+  
+            {signup &&
+              <Button color="transparent" shadowless onPress={() => navigation.navigate("SignIn")}>
+                <Text center color="#F69896" size={theme.SIZES.FONT * 0.75}>すでにアカウントをお持ちですか？ サインイン</Text>
+              </Button>
+            }
+            {signin &&
+              <Button color="transparent" shadowless onPress={() => navigation.navigate("SignUp")}>
+                <Text center color="#F69896" size={theme.SIZES.FONT * 0.75}>アカウントをお持ちではありませんか？サインアップ</Text>
+              </Button>
+            }
+            
+          </Block>
+        </Block>
+      </KeyboardAvoidingView>
+    </Block>  
+      );
+    }
+
   return (
     <LinearGradient
       start={{ x: 0, y: 0 }}
@@ -85,158 +359,14 @@ const SignInUp = (props) => {
       locations={[0.2, 1]}
       colors={["white", "mistyrose"]}
       style={[styles.container, { flex: 1, paddingTop: theme.SIZES.BASE * 4 }]}>
-      <Block flex middle>
-        <KeyboardAvoidingView behavior="padding" enabled>
-          <Block flex={0.1} style={{ alignItems: "center" }}>
-            <Text size={26} bold color="#F69896">{signup ? "アカウントを作成" : (signin && "ログイン")}</Text>
-          </Block>
-          <Block flex={0.7} center space="between">
-            <Block center>
-              {signup &&
-                <>
-                  <Input
-                    bgColor="transparent"
-                    placeholderTextColor="darkgray"
-                    borderless
-                    color="lightcoral"
-                    placeholder="ユーザネーム"
-                    autoCapitalize="none"
-                    style={[styles.input, active.username ? styles.inputActive : null]}
-                    onChangeText={text => setUsername(text)}
-                    onBlur={() => toggleActive("username", false)}
-                    onFocus={() => toggleActive("username", true)}
-                    maxLength={15}
-                  />
-                  {(active.username && !Array.isArray(errorMessages.username)) && <BottomMessage message="あなたのニックネームを入力してください。" />}
-                  {Array.isArray(errorMessages.username) &&
-                    errorMessages.username.map((message, index) => <BottomMessage message={message} error key={index} />)
-                  }
-                </>
-              }
-
-              <Input
-                bgColor="transparent"
-                placeholderTextColor="darkgray"
-                borderless
-                color="lightcoral"
-                type="email-address"
-                placeholder="メールアドレス"
-                autoCapitalize="none"
-                style={[styles.input, active.email ? styles.inputActive : null]}
-                onChangeText={text => setEmail(text)}
-                onBlur={() => toggleActive("email", false)}
-                onFocus={() => toggleActive("email", true)}
-                maxLength={225}
-              />
-              {Array.isArray(errorMessages.email) &&
-                errorMessages.email.map((message, index) => <BottomMessage message={message} error key={index} />)
-              }
-
-              <Input
-                bgColor="transparent"
-                placeholderTextColor="darkgray"
-                borderless
-                color="lightcoral"
-                password
-                viewPass
-                placeholder="パスワード"
-                iconColor="#F69896"
-                style={[styles.input, active.password ? styles.inputActive : null]}
-                onChangeText={text => setPassword(text)}
-                onBlur={() => toggleActive("password", false)}
-                onFocus={() => toggleActive("password", true)}
-                maxLength={30}
-                textContentType={'oneTimeCode'}
-              />
-              {(active.password && !Array.isArray(errorMessages.password)) && <BottomMessage message="8文字以上" />}
-              {Array.isArray(errorMessages.password) &&
-                errorMessages.password.map((message, index) => <BottomMessage message={message} error key={index} />)
-              }
-
-              {signup &&
-                <>
-                  <Block>
-                    <Button shadowless color="transparent" style={{ position: "absolute" }} onPress={() => toggleIsOpenBirthdayPicker(true)} />
-                    <Input
-                      defaultValue={typeof birthday === "undefined" ? null : `${birthday.getFullYear()}年${birthday.getMonth() + 1}月${birthday.getDate()}日`}
-                      bgColor="transparent"
-                      placeholderTextColor="darkgray"
-                      borderless
-                      color="lightcoral"
-                      placeholder="生年月日"
-                      style={[styles.input, isOpenBirthdayPicker ? styles.inputActive : null]}
-                      editable={false}
-                      selectTextOnFocus={false}
-                    />
-                  </Block>
-                  {Array.isArray(errorMessages.birthday) &&
-                    errorMessages.birthday.map((message, index) => <BottomMessage message={message} error key={index} />)
-                  }
-                  <BirthdayPicker birthday={birthday} setBirthday={setBirthday} isOpen={isOpenBirthdayPicker} setIsOpen={toggleIsOpenBirthdayPicker} />
-                </>
-              }
-
-            </Block>
-
-            {signup &&
-              <>
-                <Block/>
-                <Block style={{ marginTop: 10, flexDirection: 'row', justifyContent: 'center', alignItems: 'center' }}>
-                    <Checkbox
-                      color="#F69896"
-                      style={{ marginVertical: 8, marginHorizontal: 8, }}
-                      labelStyle={{ fontSize: 16 }}
-                      initialValue={active.userpolicy}
-                      onChange={(value) => {
-                        value ? setUserpolicy(true) : setUserpolicy(false);
-                      }}
-                      />
-                        <Text
-                          style={{color: '#0066c0'}}
-                          onPress={this._handleOpenWithWebBrowser}
-                          >利用規約
-                        </Text>
-                        <Text
-                          style={{color: '#F69896'}}
-                          onPress={this._handleOpenWithWebBrowser}
-                          >に同意する
-                        </Text>
-                </Block>
-              </>
-            }
-
-            <Block flex top style={{ marginTop: 20 }}>
-              {Array.isArray(errorMessages.error) &&
-                errorMessages.error.map((message, index) => <BottomMessage style={{ marginBottom: 10, }} textcenter message={message} error key={index} />)
-              }
-
-              <Button
-                round
-                style={{ height: 48, shadowColor: buttonColor }}
-                color={buttonColor}
-                disabled={disabled}
-                onPress={submit}
-                loading={isLoading}
-              >
-                <Text color={buttonTextColor} size={16} bold>完了</Text>
-              </Button>
-
-              {signup &&
-                <Button color="transparent" shadowless onPress={() => navigation.navigate("SignIn")}>
-                  <Text center color="#F69896" size={theme.SIZES.FONT * 0.75}>すでにアカウントをお持ちですか？ サインイン</Text>
-                </Button>
-              }
-              {signin &&
-                <Button color="transparent" shadowless onPress={() => navigation.navigate("SignUp")}>
-                  <Text center color="#F69896" size={theme.SIZES.FONT * 0.75}>アカウントをお持ちではありませんか？サインアップ</Text>
-                </Button>
-              }
-            </Block>
-          </Block>
-        </KeyboardAvoidingView>
-      </Block>
-    </LinearGradient>
-  );
+        <ScrollView ref={scrollView} style={styles.endConsultationScrollView} horizontal scrollEnabled={false}>
+        <Block flex row>
+        {FirstPage()}
+        {SecondPage()}
+        </Block>
+        </ScrollView>
+      </LinearGradient>
+  )
 }
 
 export default SignInUp;
@@ -262,5 +392,19 @@ const styles = StyleSheet.create({
   },
   inputActive: {
     borderBottomWidth: 2,
+  },
+  endConsultationScrollView: {
+    marginTop: 10,
+    backgroundColor: "white",
+    borderTopRightRadius: 17,
+    borderTopLeftRadius: 17,
+  },
+  endConsultationContainer: {
+    width: width,
+    backgroundColor: "white",
+    padding: 22,
+    paddingBottom: 40,
+    justifyContent: "flex-start",
+    alignItems: "center",
   },
 });

--- a/screensEx/Plan.js
+++ b/screensEx/Plan.js
@@ -1,360 +1,168 @@
-import React from 'react';
-import { StyleSheet, Dimensions, Image, FlatList, TouchableWithoutFeedback } from 'react-native';
-import { Button, Block, Text, theme } from 'galio-framework';
+import React, { useState } from "react";
+import { StyleSheet, Dimensions, KeyboardAvoidingView } from 'react-native';
+import { Button, Block, Text, theme, Icon } from 'galio-framework';
+import { LinearGradient } from "expo-linear-gradient";
+import * as WebBrowser from 'expo-web-browser';
 
-import { Product, Select } from '../components';
-import { materialTheme, products } from '../constants';
-import cartItems from '../constants/images/cart';
+import { materialTheme } from '../constants';
+import { USER_POLICY_URL } from "../constantsEx/env"
 
 const { width } = Dimensions.get('screen');
 
-export default class Cart extends React.Component {
-  state = {
-    cart: cartItems.products,
-  }
+//現在のユーザーのプラン状況
+let free = true
+let subscription = false
+let month = false
 
-  handleQuantity = (id, qty) => {
-    const { cart } = this.state;
+const Plan = () => {
 
-    const updatedCart = cart.map(product => {
-      if (product.id === id) product.qty = qty;
-      return product;
+    const [buttonColor, setButtonColor] = useState({
+      free: free,
+      subscription: subscription,
+      month: month,
     });
+    const [checkButton, setCheckButton] = useState({
+      free: free,
+      subscription: subscription,
+      month: month,
+    });
+    const [textColor, setTextColor] = useState({
+      free: free,
+      subscription: subscription,
+      month: month,
+    });
+    const [shadowColor, setShadowColor] = useState({
+      free: free,
+      subscription: subscription,
+      month: month,
+    });
+    
 
-    this.setState({ cart: updatedCart });
-  }
+    _handleOpenWithWebBrowser = () => {
+      WebBrowser.openBrowserAsync(USER_POLICY_URL);
+    };
 
-  handleDelete = (id) => {
-    const { cart } = this.state;
-    const updatedCart = cart.filter(product => (product.id !== id));
-    this.setState({ cart: updatedCart });
-  }
+    const changeButtonFree = () => {
+      setButtonColor({free: true}), 
+      setCheckButton({free: true}), 
+      setTextColor({free: true}), 
+      setShadowColor({free: true})
+    }
 
-  handleAdd = (item) => {
-    const { cart } = this.state;
+    const changeButtonSubscription = () => {
+      setButtonColor({subscription: true}), 
+      setCheckButton({subscription: true}), 
+      setTextColor({subscription: true}), 
+      setShadowColor({subscription: true})
+    }
 
-    cart.push({
-      ...item,
-      id: cart.length + 1,
-      stock: true,
-      qty: 1,
-    })
-
-    this.setState({ cart });
-  }
-
-  renderProduct = ({ item }) => {
-    const { navigation } = this.props;
+    const changeButtonMonth = () => {
+      setButtonColor({month: true}), 
+      setCheckButton({month: true}), 
+      setTextColor({month: true}), 
+      setShadowColor({month: true})
+    }
 
     return (
-      <Block>
-        <Block card shadow style={styles.product}>
-          <Block flex row>
-            <TouchableWithoutFeedback onPress={() => navigation.navigate('Product', { product: item })}>
-              <Block style={styles.imageHorizontal}>
-                <Image
-                  source={{ uri: item.image }}
-                  style={{ height: theme.SIZES.BASE * 5, marginTop: -theme.SIZES.BASE * 2, borderRadius: 3 }}
-                />
-              </Block>
-            </TouchableWithoutFeedback>
-            <Block flex style={styles.productDescription}>
-              <TouchableWithoutFeedback onPress={() => navigation.navigate('Product', { product: item })}>
-                <Text size={14} style={styles.productTitle}>{item.title}</Text>
-              </TouchableWithoutFeedback>
-              <Block flex row space="between">
-                <Block bottom>
-                  <Text
-                    size={theme.SIZES.BASE * 0.75}
-                    color={materialTheme.COLORS[item.stock ? 'SUCCESS' : 'ERROR']}>
-                    {item.stock ? 'In Stock' : 'Out of Stock'}
-                  </Text>
-                </Block>
-                <Block bottom>
-                  <Text
-                    size={theme.SIZES.BASE * 0.75}
-                    color={materialTheme.COLORS.ACTIVE}>
-                    $ {item.price * item.qty}
-                  </Text>
-                </Block>
-              </Block>
+      <LinearGradient
+      start={{ x: 0, y: 0 }}
+      end={{ x: 0.25, y: 1.1 }}
+      locations={[0.2, 1]}
+      colors={["white", "mistyrose"]}
+      style={[styles.container, { flex: 1}]}>
+      <Block flex row>
+      <Block flex middle>
+      <KeyboardAvoidingView behavior="padding" enabled>
+        <Block flex={0.1} style={{ alignItems: "center" }}>
+          <Text size={26} bold color="#F69896">プラン一覧</Text>
+        </Block>
+        <Block flex={0.7}  space="between">
+          <Block flex style={{ marginTop: 20 }}>
+            <Button
+              style={{ height: 80, shadowColor: shadowColor.free ? "silver" : "lightcoral", borderRadius: 20, flexDirection: 'row' }}
+              color={buttonColor.free ? "white" : "lightcoral"}
+              //disabled={" "}
+              onPress={changeButtonFree}
+              //loading={" "}
+            >
+              <Text color={textColor.free ? "lightcoral" : "white"} size={20} bold>2週間無料お試し</Text>
+              { checkButton.free &&
+                <Icon family="font-awesome" name="check-circle" size={30} color="lightcoral" styles={{paddingRight: 30}}/>
+              }
+            </Button>
+            <Block style={{padding: 10, paddingBottom: 20}}>
+              <Text color="silver" size={12} bold center>お試し期間終了後自動でノーマルに更新されます。</Text>
+              <Text color="silver" size={12} bold center>キャンセルしない限り、プランは毎月自動更新されます。</Text>
             </Block>
-          </Block>
-          <Block flex row space="between" style={styles.options}>
-            <Block>
-              <Select
-                defaultIndex={1}
-                disabled={!item.stock}
-                options={[1, 2, 3, 4, 5]}
-                onSelect={(index, value) => this.handleQuantity(item.id, value)}
-              />
+            
+            <Button
+              style={{ height: 80, shadowColor: shadowColor.subscription ? "silver" : "lightcoral", borderRadius: 20, flexDirection: 'row' }}
+              color={buttonColor.subscription ? "white" : "lightcoral"}
+              //disabled={" "}
+              onPress={changeButtonSubscription}
+              //loading={" "}
+            >
+              <Block style={{flexDirection: 'column', justifyContent: 'center', alignItems: 'center'}}>
+                <Text color={textColor.subscription ? "lightcoral" : "white"} size={20} bold>ノーマル</Text>
+                <Text color={textColor.subscription ? "lightcoral" : "white"} size={16} bold>￥500 / 月</Text>
+              </Block>
+              { checkButton.subscription &&
+                <Icon family="font-awesome" name="check-circle" size={30} color="lightcoral" styles={{alignItems: "right"}}/>
+              }
+            </Button>
+            <Block style={{padding: 10, paddingBottom: 20}}>
+              <Text color="silver" size={12} bold center>キャンセルしない限り、プランは毎月自動更新されます。</Text>
             </Block>
             <Button
-              center
-              shadowless
-              color={materialTheme.COLORS.INPUT}
-              textStyle={styles.optionsButtonText}
-              style={styles.optionsButton}
-              onPress={() => this.handleDelete(item.id)}
+              style={{ height: 80, shadowColor: shadowColor.month ? "silver" : "lightcoral", borderRadius: 20, flexDirection: 'row' }}
+              color={buttonColor.month ? "white" : "lightcoral"}
+              //disabled={" "}
+              onPress={changeButtonMonth}
+              //loading={" "}
             >
-              DELETE
+              <Block style={{flexDirection: 'column', justifyContent: 'center', alignItems: 'center'}}>
+                <Text color={textColor.month ? "lightcoral" : "white"} size={20} bold>1month</Text>
+                <Text color={textColor.month ? "lightcoral" : "white"} size={16} bold>￥700</Text>
+              </Block>
+              { checkButton.month &&
+                <Icon family="font-awesome" name="check-circle" size={30} color="lightcoral" styles={{alignItems: "right"}}/>
+              }
             </Button>
-            <Button
-              center
-              shadowless
-              color={materialTheme.COLORS.INPUT}
-              textStyle={styles.optionsButtonText}
-              style={styles.optionsButton}
-              onPress={() => console.log('save for later')}
-            >
-              SAVE FOR LATER
-            </Button>
+            <Block style={{padding: 10, paddingBottom: 20}}>
+              <Text color="silver" size={12} bold center>一ヶ月のみのプランです。</Text>
+            </Block>
+  
+            <Block style={{padding: 10}}>
+              <Text color="lightcoral" size={12} bold center>購入を復元する</Text>
+            </Block>
+            <Block style={{padding: 10, flexDirection: 'row', justifyContent: 'center', alignItems: 'center'}}>
+            <Text color="#F69896" size={12} bold center onPress={_handleOpenWithWebBrowser}
+              >利用規約
+            </Text>
+            <Text
+              color="silver" size={12} bold center
+              >と
+            </Text>
+              <Text
+              color="#F69896" size={12} bold center
+              onPress={_handleOpenWithWebBrowser}
+              >プライバシーポリシー
+            </Text>
+            </Block>
+            
           </Block>
         </Block>
-      </Block>
-    )
-  }
-
-  renderHorizontalProduct = ({ item }) => {
-    return (
-      <Block style={{ marginRight: theme.SIZES.BASE }}>
-        <Product
-          product={item}
-          priceColor={materialTheme.COLORS.ACTIVE}
-          imageStyle={{ width: 'auto', height: 94 }}
-          style={{ width: width / 2.88 }}
-        />
-        <Button
-          center
-          shadowless
-          color={materialTheme.COLORS.ACTIVE}
-          style={styles.optionsButton}
-          textStyle={[styles.optionsButtonText, { color: 'white' }]}
-          onPress={() => this.handleAdd(item)}
-        >
-          ADD TO CART
-        </Button>
-      </Block>
-    )
-  }
-
-  renderHorizontalProducts = () => {
-    return (
-      <Block style={{ marginHorizontal: theme.SIZES.BASE }}>
-        <Text bold size={theme.SIZES.BASE} style={styles.similarTitle}>
-          Customers who shopped for items in your cart also shopped for:
-        </Text>
-        <FlatList
-          data={cartItems.suggestions}
-          horizontal={true}
-          showsHorizontalScrollIndicator={false}
-          keyExtractor={(item, index) => `${index}-${item.title}`}
-          renderItem={this.renderHorizontalProduct}
-        />
-      </Block>
-    )
-  }
-
-  renderDivider() {
-    return (
-      <Block style={styles.divider} />
-    )
-  }
-
-  renderHeader = () => {
-    const { navigation } = this.props;
-    const { cart } = this.state;
-    const productsQty = cart.length;
-    const total = cart && cart.reduce((prev, product) => prev + (product.price * product.qty), 0);
-
-    return (
-      <Block flex style={styles.header}>
-        <Block style={{ marginBottom: theme.SIZES.BASE * 2 }}>
-          <Text>
-            Cart subtotal ({productsQty} items):
-            <Text color={materialTheme.COLORS.ERROR} bold>${total}</Text>
-          </Text>
-        </Block>
-        <Block center>
-          <Button flex center style={styles.checkout}
-            color={materialTheme.COLORS.ACTIVE}
-            onPress={() => navigation.navigate('Sign In')} >
-            PROCEED TO CHECKOUT
-          </Button>
-        </Block>
-        <Block style={styles.divider} />
-      </Block>
-    )
-  }
-
-  renderFooter = () => {
-    const { navigation } = this.props;
-    return (
-      <Block flex style={styles.footer}>
-        {this.renderHorizontalProducts()}
-        <Block style={{ marginHorizontal: theme.SIZES.BASE }}>
-          <Block style={styles.divider} />
-        </Block>
-        <Block center style={{ paddingHorizontal: theme.SIZES.BASE }}>
-          <Button flex center style={styles.checkout}
-            color={materialTheme.COLORS.ACTIVE}
-            onPress={() => navigation.navigate('SignIn')} >
-            PROCEED TO CHECKOUT
-          </Button>
-        </Block>
-      </Block>
-    )
-  }
-
-  renderEmpty() {
-    return (
-      <Text color={materialTheme.COLORS.ERROR}>The cart is empty</Text>
+      </KeyboardAvoidingView>
+    </Block>
+    </Block>
+    </LinearGradient>
     );
-  }
-
-  renderCheckoutButton() {
-    const { navigation } = this.props;
-    return (
-      <Block center>
-        <Button
-          flex
-          center
-          style={styles.checkout}
-          color={materialTheme.COLORS.ACTIVE}
-          onPress={() => navigation.navigate('SignIn')} >
-          PROCEED TO CHECKOUT
-          </Button>
-      </Block>
-    )
-  }
-
-  render() {
-    return (
-      <Block flex center style={styles.cart}>
-        <FlatList
-          data={this.state.cart}
-          renderItem={this.renderProduct}
-          showsVerticalScrollIndicator={false}
-          keyExtractor={(item, index) => `${index}-${item.title}`}
-          ListEmptyComponent={this.renderEmpty()}
-          ListHeaderComponent={this.renderHeader()}
-          ListFooterComponent={this.renderFooter()} />
-      </Block>
-    );
-  }
 }
 
+export default Plan;
+
 const styles = StyleSheet.create({
-  cart: {
-    width: width,
-  },
-  header: {
-    paddingVertical: theme.SIZES.BASE,
-    marginTop: theme.SIZES.BASE * 2,
-    marginHorizontal: theme.SIZES.BASE,
-  },
-  footer: {
-    marginBottom: theme.SIZES.BASE * 2,
-  },
-  divider: {
-    height: 1,
-    backgroundColor: materialTheme.COLORS.INPUT,
-    marginVertical: theme.SIZES.BASE,
-  },
-  checkoutWrapper: {
-    paddingTop: theme.SIZES.BASE * 2,
-    margin: theme.SIZES.BASE,
-    borderStyle: "solid",
-    borderTopWidth: 1,
-    borderTopColor: materialTheme.COLORS.INPUT,
-  },
-  products: {
-    minHeight: '100%',
-  },
-  product: {
-    width: width * 0.9,
-    borderWidth: 0,
-    marginVertical: theme.SIZES.BASE * 1.5,
-    marginHorizontal: theme.SIZES.BASE,
-    backgroundColor: theme.COLORS.WHITE,
-    shadowColor: "black",
-    shadowOffset: { width: 0, height: 2 },
-    shadowRadius: theme.SIZES.BASE / 4,
-    shadowOpacity: 0.1
-  },
-  productTitle: {
-    flex: 1,
-    flexWrap: 'wrap',
-    paddingBottom: 6,
-  },
-  productDescription: {
-    padding: theme.SIZES.BASE / 2,
-  },
-  imageHorizontal: {
-    width: theme.SIZES.BASE * 6.25,
-    margin: theme.SIZES.BASE / 2,
-  },
-  options: {
-    padding: theme.SIZES.BASE / 2,
-  },
-  qty: {
-    display: 'flex',
-    justifyContent: 'center',
-    alignContent: 'center',
-    width: theme.SIZES.BASE * 6.25,
-    backgroundColor: materialTheme.COLORS.INPUT,
-    paddingHorizontal: theme.SIZES.BASE,
-    paddingVertical: 10,
-    borderRadius: 3,
-    shadowColor: "rgba(0, 0, 0, 0.1)",
-    shadowOffset: { width: 0, height: 2 },
-    shadowRadius: 4,
-    shadowOpacity: 1,
-  },
-  optionsButtonText: {
-    fontSize: theme.SIZES.BASE * 0.75,
-    color: '#4a4a4a',
-    fontWeight: "normal",
-    fontStyle: "normal",
-    letterSpacing: -0.29,
-  },
-  optionsButton: {
-    width: 'auto',
-    height: 34,
-    paddingHorizontal: theme.SIZES.BASE,
-    paddingVertical: 10,
-    borderRadius: 3,
-    shadowColor: "rgba(0, 0, 0, 0.1)",
-    shadowOffset: { width: 0, height: 2 },
-    shadowRadius: 4,
-    shadowOpacity: 1,
-  },
-  checkout: {
-    height: theme.SIZES.BASE * 3,
-    shadowColor: "black",
-    shadowOffset: { width: 0, height: 4 },
-    shadowRadius: 8,
-    shadowOpacity: 0.2,
-  },
-  similarTitle: {
-    lineHeight: 26,
-    marginBottom: theme.SIZES.BASE,
-    paddingHorizontal: theme.SIZES.BASE,
-  },
-  productVertical: {
-    height: theme.SIZES.BASE * 10.75,
-    width: theme.SIZES.BASE * 8.125,
-    overflow: 'hidden',
-    borderWidth: 0,
-    borderRadius: 4,
-    marginBottom: theme.SIZES.BASE,
-    backgroundColor: theme.COLORS.WHITE,
-    shadowColor: "rgba(0, 0, 0, 0.1)",
-    shadowOffset: {
-      width: 0,
-      height: 2
-    },
-    shadowRadius: theme.SIZES.BASE / 4,
-    shadowOpacity: 1
+  container: {
+    marginTop: Platform.OS === "android" ? -HeaderHeight : 0,
   }
 });

--- a/screensEx/SignIn.js
+++ b/screensEx/SignIn.js
@@ -3,13 +3,13 @@ import axios from "axios";
 
 import { BASE_URL } from "../constantsEx/env";
 import { URLJoin } from "../componentsEx/tools/support";
-import SignInUp from "../componentsEx/templates/SignInUpTemplate";
+import SignIn from "../componentsEx/templates/SignInInTemplate";
 import { startUpLogind } from "./Manager";
 
 
 const SignIn = (props) => {
   return (
-    <SignInUp {...props} signin requestSignIn={requestSignIn} />
+    <SignIn {...props} signin requestSignIn={requestSignIn} />
   );
 }
 


### PR DESCRIPTION
① 登録画面でのプラン選択
⇒個人情報を入力した後に、プラン選択の画面に遷移し選択できる実装
⇒ボタンを一つ押すとすべてのインジケーターが動いてしまうが、バックの処理がかかわっていそうなのでそのままにしている。
⇒signupテンプレートで登録とログイン画面を兼ねていたが、signin signupのテンプレートを別で製作した

➁アプリ内のプラン選択画面
⇒登録画面を参考にしている