### PR TITLE
登録画面での性別の選択と設定画面での異性と相談可否のチェックボックス

### DIFF
--- a/componentsEx/organisms/Profile.js
+++ b/componentsEx/organisms/Profile.js
@@ -93,9 +93,9 @@ export const ConsultantProfile = (props) => {
 
       <Catalogue title="特徴" items={user.features} />
       <ProfileHr />
-      <Catalogue title="対応できる悩みのジャンル" items={user.genreOfWorries} />
+      <Catalogue title="話したい悩みのジャンル" items={user.genreOfWorries} />
       <ProfileHr />
-      <Catalogue title="対応できる悩みの大きさ" items={user.scaleOfWorries} />
+      <Catalogue title="話せる悩みの大きさ" items={user.scaleOfWorries} />
       <ProfileHr />
       <Catalogue title="共感できる悩み" items={user.worriesToSympathize} />
       <ProfileHr />
@@ -227,9 +227,9 @@ export const ConsultantProfileEditor = (props) => {
 
         <Catalogue title="特徴" items={user.features} isEditor onPress={() => navigation.navigate("ProfileInput", { user: user, prevValue: user.features, screen: "InputFeature" })} />
         <ProfileHr />
-        <Catalogue title="対応できる悩みのジャンル" items={user.genreOfWorries} isEditor onPress={() => navigation.navigate("ProfileInput", { user: user, prevValue: user.genreOfWorries, screen: "InputGenreOfWorries" })} />
+        <Catalogue title="話したい悩みのジャンル" items={user.genreOfWorries} isEditor onPress={() => navigation.navigate("ProfileInput", { user: user, prevValue: user.genreOfWorries, screen: "InputGenreOfWorries" })} />
         <ProfileHr />
-        <Catalogue title="対応できる悩みの大きさ" items={user.scaleOfWorries} isEditor onPress={() => navigation.navigate("ProfileInput", { user: user, prevValue: user.scaleOfWorries, screen: "InputScaleOfWorries" })} />
+        <Catalogue title="話せる悩みの大きさ" items={user.scaleOfWorries} isEditor onPress={() => navigation.navigate("ProfileInput", { user: user, prevValue: user.scaleOfWorries, screen: "InputScaleOfWorries" })} />
         <ProfileHr />
         <Catalogue title="共感できる悩み" items={user.worriesToSympathize} isEditor onPress={() => navigation.navigate("ProfileInput", { user: user, prevValue: user.worriesToSympathize, screen: "InputWorriesToSympathize" })} />
       </Block >

--- a/componentsEx/templates/SignInUpTemplate.js
+++ b/componentsEx/templates/SignInUpTemplate.js
@@ -21,11 +21,15 @@ const SignInUp = (props) => {
   const [password, setPassword] = useState("");
   const [birthday, setBirthday] = useState();
   const [userpolicy, setUserpolicy] = useState();
+  const [male, setMale] = useState();
+  const [female, setFemale] = useState();
   const [active, setActive] = useState({
     username: false,
     email: false,
     password: false,
-    userpolicy: false
+    userpolicy: false,
+    male: false,
+    female: false
   });
   const errorMessagesInit = {
     username: "",
@@ -60,13 +64,15 @@ const SignInUp = (props) => {
   const { navigation, signup, signin, requestSignUp, requestSignIn } = props;
   let buttonColor;
   let buttonTextColor;
+  let gender
   let submit;
   let disabled = true;
-  if ((signup && username && email && password && birthday && userpolicy) || (signin && email && password)) {
+  if ((signup && username && email && password && birthday && userpolicy) && ((male && !female) || (female && !male))|| (signin && email && password)) {
     buttonColor = "lightcoral";
     buttonTextColor = "white";
+    male ? gender = "male" : gender = "female"
     if (signup) {
-      submit = () => requestSignUp(username, email, password, birthday, dispatches, chatState, setErrorMessages, errorMessagesInit, setIsLoading);
+      submit = () => requestSignUp(username, email, password, birthday, gender, dispatches, chatState, setErrorMessages, errorMessagesInit, setIsLoading);
     } else if (signin) {
       submit = () => requestSignIn(email, password, dispatches, chatState, setErrorMessages, errorMessagesInit, setIsLoading);
     }
@@ -80,7 +86,6 @@ const SignInUp = (props) => {
     WebBrowser.openBrowserAsync(USER_POLICY_URL);
   };
 
-  
   const [currentPage, setCurrentPage] = useState(1);
   const maxPage = 1;
   const scrollView = useRef(null);
@@ -198,6 +203,34 @@ const SignInUp = (props) => {
             }
 
           </Block>
+
+          {signup &&
+            <>
+              <Block/>
+              <Block style={{ marginTop: 10, flexDirection: 'row', justifyContent: 'center', alignItems: 'center' }}>
+                  <Checkbox
+                    color="#F69896"
+                    style={{ marginVertical: 8, marginHorizontal: 8, }}
+                    labelStyle={{ color: '#F69896' }}
+                    label="女性"
+                    initialValue={active.female}
+                    onChange={(value) => {
+                      value ? setFemale(true) : setFemale(false);
+                    }}
+                    />
+                    <Checkbox
+                    color="#F69896"
+                    style={{ marginVertical: 8, marginHorizontal: 8, }}
+                    labelStyle={{ color: '#F69896' }}
+                    label="男性"
+                    initialValue={active.male}
+                    onChange={(value) => {
+                      value ? setMale(true) : setMale(false);
+                    }}
+                    />
+              </Block>
+            </>
+          }
 
           {signup &&
             <>

--- a/screensEx/Settings.js
+++ b/screensEx/Settings.js
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { StyleSheet, Dimensions, ScrollView, TouchableOpacity } from "react-native";
-import { Block, theme, Text, Input, Button } from "galio-framework";
+import { Block, theme, Text, Input, Button, Checkbox } from "galio-framework";
 import * as WebBrowser from "expo-web-browser";
 
 import { Hr, Icon } from "../componentsEx";
@@ -34,6 +34,8 @@ const Settings = (props) => {
     return (
       <ScrollView>
         <SettingsTitle title="アカウント" />
+        <SettingsCheckBox title="異性との相談を許可" />
+        <SettingsExplain explain="異性との相談を許可している他ユーザーも一覧に表示され相談ができるようになります。" />
         <SettingsCard title="メールアドレス" onPress={() => navigation.navigate("SettingsInput", { screen: "InputMailAdress" })} />
         <SettingsCard title="パスワード" onPress={() => navigation.navigate("SettingsInput", { screen: "InputPassword" })} />
         <SettingsButton title="ログアウト" color="crimson" onPress={() => {
@@ -106,6 +108,15 @@ const SettingsTitle = (props) => {
   );
 }
 
+const SettingsExplain = (props) => {
+  const { explain } = props;
+  return (
+    <Block flex style={{ paddingHorizontal: 15, paddingTop: 5, paddingBottom: 25, marginTop: 5 }}>
+      <Text size={12} bold color="gray" >{explain}</Text>
+    </Block>
+  );
+}
+
 const SettingsCard = (props) => {
   const { title, onPress } = props;
   return (
@@ -133,6 +144,30 @@ const SettingsLabel = (props) => {
         </Block>
         <Block style={{ alignItems: "center", justifyContent: "center" }} >
           <Text size={15} color="dimgray" style={{ marginHorizontal: 15 }}>{content}</Text>
+        </Block>
+      </Block>
+      <Hr h={1} color="whitesmoke" />
+    </>
+  );
+}
+
+const SettingsCheckBox = (props) => {
+  const { title } = props;
+  return (
+    <>
+      <Block flex row space="between" style={styles.settingsCard}>
+        <Block>
+          <Text bold size={15} color="dimgray" style={{ marginHorizontal: 15 }}>{title}</Text>
+        </Block>
+        <Block style={{ alignItems: "center", justifyContent: "center" }} >
+        <Checkbox
+                    color="#F69896"
+                    style={{ marginVertical: 8, marginHorizontal: 15, }}
+                    labelStyle={{ color: '#F69896' }}
+                    onChange={(value) => {
+                      
+                    }}
+                    />
         </Block>
       </Block>
       <Hr h={1} color="whitesmoke" />


### PR DESCRIPTION
➀登録画面での性別選択のチェックボックス
⇒現状どちらも選択できてしまうが、その場合「次へ」は押せないので、二つの性別を持つユーザは生まれない

➁設定画面での異性と相談可否のチェックボックス
⇒結局設定画面に実装。デザインはlineを参照

➂プロフィールの文言修正
⇒対応できる～っていう文言を話したい～に変更