### PR TITLE
firebaseのevent設定

### DIFF
--- a/components/molecules/ChatModal.js
+++ b/components/molecules/ChatModal.js
@@ -12,7 +12,7 @@ import { BASE_URL } from "../../constants/env";
 import { useAuthState } from "../contexts/AuthContext";
 import { useChatDispatch, useChatState } from "../contexts/ChatContext";
 import { useProfileState } from "../contexts/ProfileContext";
-
+import { logEvent } from "../modules/firebase/logEvent"
 
 const { width, height } = Dimensions.get("screen");
 
@@ -67,6 +67,9 @@ const ChatModal = (props) => {
       cancelButton: "キャンセル",
       okButton: "停止する",
       onPress: () => {
+        logEvent("stop_talk_button", {
+          job: profileState.profile.job?.label,
+        });
         setIsShowSpinner(true);
         request({
           data: {
@@ -92,6 +95,12 @@ const ChatModal = (props) => {
       cancelButton: "キャンセル",
       okButton: "探す",
       onPress: () => {
+        logEvent("shuffle_talk_button", {
+          is_speaker: isSpeaker,
+          can_talk_heterosexual: canTalkHeterosexual,
+          can_talk_different_job: canTalkDifferentJob,
+          job: profileState.profile.job?.label,
+        });
         setIsShowSpinner(true);
         request({
           data: {

--- a/components/organisms/Chat.js
+++ b/components/organisms/Chat.js
@@ -11,6 +11,7 @@ import { useAxios } from "../modules/axios";
 import { ADMOB_UNIT_ID_AFTER_THX, BASE_URL, isExpo } from "../../constants/env";
 import { AdMobInterstitial } from "react-native-admob";
 import { useAuthDispatch } from "../contexts/AuthContext";
+import {logEvent} from "../modules/firebase/logEvents"
 
 
 const { width, height } = Dimensions.get("screen");
@@ -96,6 +97,7 @@ export const EndTalkScreen = (props) => {
     let pushed = false;
     const pushThunks = () => {
       if (!pushed) {
+        logEvent("thx_button");
         pushed = true;
         animation.current.play();
         setTimeout(() => {
@@ -104,6 +106,7 @@ export const EndTalkScreen = (props) => {
       }
     }
     const pushSkip = () => {
+      logEvent("slip_thx_button");
       request({
         data: {
           has_thunks: false,

--- a/components/organisms/Header.js
+++ b/components/organisms/Header.js
@@ -14,7 +14,7 @@ import { ProfileMenuButton } from "./ProfileMenuButton";
 import { checkiPhoneX } from "../modules/support";
 import { useProfileState } from "../contexts/ProfileContext";
 import ProfileModal from "../molecules/ProfileModal";
-
+import {logEvent} from "../modules/firebase/logEvent"
 
 const { height, width } = Dimensions.get("window");
 
@@ -40,6 +40,8 @@ const Header = (props) => {
 
   const renderRight = () => {
     const routeName = scene.route.name;
+    if (routeName === "Chat" && talkTicketKey) {
+    logEvent("shuffle_option_button")}
     if (routeName === "Chat" && talkTicketKey) return (
       <TalkMenuButton key="TalkMenuButton" navigation={navigation} talkTicketKey={talkTicketKey} />
     );

--- a/components/templates/ChatTemplate.js
+++ b/components/templates/ChatTemplate.js
@@ -8,7 +8,7 @@ import Avatar from "../atoms/Avatar";
 import { generateUuid4, fmtfromDateToStr, isObject } from "../modules/support";
 import { useChatDispatch, useChatState } from "../contexts/ChatContext";
 import ProfileModal from "../molecules/ProfileModal";
-
+import { logEvent } from "../modules/firebase/logEvent";
 
 const { width } = Dimensions.get("screen");
 
@@ -116,6 +116,10 @@ const ChatTemplate = (props) => {
         alert("話し相手が見つかりません。");
         return;
       }
+      logEvent("send_message_button", {
+        message: message,
+        talkTicketKey: talkTicketKey
+      });
       const messageID = generateUuid4();
       appendOfflineMessage(messageID, message);
       setMessage("");

--- a/components/templates/signup/signupPages/SecondSignUpPage.js
+++ b/components/templates/signup/signupPages/SecondSignUpPage.js
@@ -5,6 +5,7 @@ import SignUpPageTemplate from "./SignUpPageTemplate";
 import { useAuthDispatch } from "../../../contexts/AuthContext";
 import { useProfileState } from "../../../contexts/ProfileContext";
 import BubbleList from "../../../organisms/BubbleList";
+import logEvent from "../../../modules/firebase/logEvent"
 
 
 const { width, height } = Dimensions.get("screen");
@@ -26,6 +27,9 @@ const SecondSignUpPage = (props) => {
   const pressButton = () => {
     authDispatch({ type: "TO_PROGRESS_SIGNUP", didProgressNum: progressNum, isFinished: false, });
     authDispatch({ type: "SET_WORRIES_BUFFER", worries: Object.values(worriesCollection), });
+    logEvent("intro_worry_bubble", {
+      worries: Object.values(worriesCollection),
+    });
 
     goToPage(progressNum + 1);
   }

--- a/components/templates/signup/signupPages/ThirdSignUpPage.js
+++ b/components/templates/signup/signupPages/ThirdSignUpPage.js
@@ -13,7 +13,7 @@ import { COLORS } from "../../../../constants/Theme";
 import { MenuModal } from "../../../molecules/Menu";
 import { startUpLoggedin } from "../../../../screens/StartUpManager";
 import useAllContext from "../../../contexts/ContextUtils";
-
+import { logEvent } from "../../../modules/firebase/logEvent"
 
 const { height, width } = Dimensions.get("window");
 
@@ -72,6 +72,12 @@ const ThirdSignUpPage = (props) => {
   });
 
   const pressButton = () => {
+    logEvent("intro_user_info_button", {
+      username: username,
+      genre_of_worries: authState.signupBuffer.worries,
+      gender: gender,
+      job: job,
+    });
     request();
   }
 


### PR DESCRIPTION
- 最初の悩み選択画面の次へボタン
- 最初の個人情報入力完了後の次へのボタン
- home画面右上のシャッフルボタン
- シャッフル条件選択モーダルでのシャッフルボタン
- ハートボタン
- ハート下のスキップボタン
- メッセージ送信ボタン

それぞれeventの名前以外にもfirebaseで表示したい値を追記してるんで、ロジック的にスコープ的におかしければ修正してくれると助かる。