### PR TITLE
マッチしたときのみ緑アイコンで表示

### DIFF
--- a/components/atoms/StatusIcon.js
+++ b/components/atoms/StatusIcon.js
@@ -1,0 +1,35 @@
+import React from "react";
+import { StyleSheet } from "react-native";
+import { theme, Block } from "galio-framework";
+
+
+const StatusIcon = () => {
+  return (
+  <Block style={[styles.statusContainer]}>
+    <Block style={[styles.statusIcon, { backgroundColor: "#6dd39d" }]} />
+  </Block>
+  )
+}
+
+export default StatusIcon;
+
+const styles = StyleSheet.create({
+statusContainer: {
+  width: 12,
+  height: 12,
+  zIndex: 1,
+  position: "absolute",
+  top: -7,
+  left: theme.SIZES.BASE / 1.4,
+  flex: 1,
+  justifyContent: "flex-start",
+  alignItems: "center",
+  borderRadius: 8,
+  backgroundColor: "white"
+},
+statusIcon: {
+  top: 2,
+  width: 8,
+  height: 8,
+  borderRadius: 6,
+},})

--- a/components/contexts/ChatContext.js
+++ b/components/contexts/ChatContext.js
@@ -365,11 +365,11 @@ const geneCommonMessage = (type, user_name = "", timeOut = false) => {
   switch (type) {
     case "initSpeak":
       message["id"] = 0;
-      message["message"] = `トークが開始されました。${user_name}さんに話を聞いてもらいましょう。`;
+      message["message"] = `話し相手が見つかりました！${user_name}さんに話を聞いてもらいましょう。`;
       break;
     case "initListen":
       message["id"] = 0;
-      message["message"] = `トークが開始されました。${user_name}さんのお話を聞いてあげましょう。`;
+      message["message"] = `話し相手が見つかりました！${user_name}さんのお話を聞いてあげましょう。`;
       break;
     case "alert":
       message["id"] = 2;

--- a/components/molecules/Card.js
+++ b/components/molecules/Card.js
@@ -3,7 +3,7 @@ import { StyleSheet, Dimensions, TouchableWithoutFeedback } from "react-native";
 import { Block, Text, theme } from "galio-framework";
 import Icon from "../atoms/Icon";
 import { COLORS } from "../../constants/Theme";
-
+import StatusIcon from "../atoms/StatusIcon";
 
 const { width } = Dimensions.get("screen");
 
@@ -50,6 +50,7 @@ const Card = (props) => {
           </Block> :
 
           <Block flex style={styles.content}>
+            {item.content.includes("話し相手が見つかりました！") && <StatusIcon/>}
             <Block row style={[styles.titleContainer, { height: titleSize + 5 }]}>
               <Text
                 bold


### PR DESCRIPTION
マッチしたときだけ緑の○ポチが表示されるようにしました。
探し中のぽち⇒今探し中なんだと連想しずらい
話中のぽちとか⇒通知で賄える

マッチしたとき気付いてないのでは？という仮説に対して、気づかせるためにフォーカス（マッチ時のみの緑ぽち）することで、○ポチ自体の意味が「マッチしたよ！」を強めると思った。
逆に、それぞれぽちがあると、マッチ時のぽちが何を刺しているのかの意味が弱まり、今回の仮説に対する効果が薄まる気がした。

マッチ時のメッセージを「話し相手が見つかったよ！」に変更。トークが開始されただと、「急やな」感。

○ポチのサイズや位置は不服があれば、意見ください。自分も決定的な理由があるわけではない。

1つ案として右上に全て配置するのはある
探し中⇒くるくる（くるくるがずっと続くのは読み込みが終わらないという負を生むみたいな話があったが、探し中、準備中はくるくるのイメージがやはり強い）
マッチ⇒緑ぽち等
トーク中⇒未読だった時に表示される赤丸数字
離脱中⇒なし